### PR TITLE
ramips: add support for Amped Wireless ALLY router and extender

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -25,6 +25,10 @@ allnet,all0256n-8m|\
 allnet,all5002)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;
+ampedwireless,ally-00x19k|\
+ampedwireless,ally-r1900k)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000" "4"
+	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 mediatek,linkit-smart-7688|\

--- a/target/linux/ramips/dts/mt7621_ampedwireless_ally-00x19k.dts
+++ b/target/linux/ramips/dts/mt7621_ampedwireless_ally-00x19k.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_ampedwireless_ally.dtsi"
+
+/ {
+	compatible = "ampedwireless,ally-00x19k", "mediatek,mt7621-soc";
+	model = "Amped Wireless ALLY-00X19K";
+
+};
+
+&switch0 {
+	ports {
+
+		port@2 {
+			status = "okay";
+			label = "lan";
+		};
+
+	};
+};

--- a/target/linux/ramips/dts/mt7621_ampedwireless_ally-r1900k.dts
+++ b/target/linux/ramips/dts/mt7621_ampedwireless_ally-r1900k.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_ampedwireless_ally.dtsi"
+
+/ {
+	compatible = "ampedwireless,ally-r1900k", "mediatek,mt7621-soc";
+	model = "Amped Wireless ALLY-R1900K";
+
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+

--- a/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
+++ b/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		led {
+			label = "led";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "ally:green:status";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_amber: status_amber {
+			label = "ally:amber:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			label = "ally:red:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		compatible = "pci14c3,7615";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi1: wifi@0,0 {
+		compatible = "pci14c3,7615";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "i2c";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	status = "enabled";
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		/*
+		 * uboot expects to find kernels at 0x140000 & 0x2140000,
+		 * referred to as Uimage & Uimage1 in factory FW, respectively.
+		 * U-boot variable 'bootImage' controls which is booted;
+		 * 0 for the first, 1 for the 2nd.
+		 * There's a 3rd partition, Uimage2 (0x4140000), which
+		 * I expected to be a recovery image, but is actually blank.
+		 *
+		 * A kernel is considered suitable for handing control over
+		 * if its linux magic number exists & uImage CRC are correct.
+		 * If either of those conditions fail, 'bootImage' value
+		 * is toggled in uboot env & a restart performed in the hope that the
+		 * alternate kernel is okay.
+		 *
+		 * Note uboot's tftp flash install writes the transferred
+		 * image to the active kernel partition.
+		 */
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x2000000>;	    /* 32MB */
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x1C00000>;
+			};
+
+		};
+
+		partition@2140000 {
+			label = "oem";
+			reg = <0x2140000 0x2000000>;	/* 32MB */
+		};
+
+		partition@4140000 {
+			label = "backup";
+			reg = <0x4140000 0x2000000>;	/* 32MB */
+		};
+
+		partition@6140000 {
+			label = "chime";
+			reg = <0x6140000 0xa00000>;
+		};
+
+		partition@6b40000 {
+			label = "data";
+			reg = <0x6b40000 0xa00000>;
+		};
+
+		partition@7540000 {
+			label = "reserved";
+			reg = <0x7540000 0x840000>;
+			read-only;
+		};
+
+		partition@7d80000 {
+			label = "nvram";
+			reg = <0x7d80000 0x100000>;
+			read-only;
+		};
+
+		partition@7e80000 {
+			label = "hwconfig";
+			reg = <0x7e80000 0x100000>;
+			read-only;
+		};
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -140,6 +140,38 @@ define Device/alfa-network_quad-e4g
 endef
 TARGET_DEVICES += alfa-network_quad-e4g
 
+define Device/ampedwireless_ally-r1900k
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  FILESYSTEMS := squashfs ubifs
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 32768k
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage flashable-initramfs |\
+     edimax-header -s CSYS -m RN68 -f 0x001c0000 -S 0x01100000
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Amped Wireless
+  DEVICE_MODEL := ALLY-R1900K
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware uboot-envtools kmod-usb3
+endef
+TARGET_DEVICES += ampedwireless_ally-r1900k
+
+define Device/ampedwireless_ally-00x19k
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  FILESYSTEMS := squashfs ubifs
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 32768k
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage flashable-initramfs |\
+     edimax-header -s CSYS -m RN68 -f 0x001c0000 -S 0x01100000
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Amped Wireless
+  DEVICE_MODEL := ALLY-00X19K
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware uboot-envtools
+endef
+TARGET_DEVICES += ampedwireless_ally-00x19k
+
 define Device/asiarf_ap7621-001
   $(Device/dsa-migration)
   IMAGE_SIZE := 16000k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ramips_setup_interfaces()
 	xiaomi,mir3g-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	ampedwireless,ally-00x19k|\
 	edimax,re23s|\
 	mikrotik,routerboard-m11g|\
 	netgear,ex6150|\
@@ -30,6 +31,7 @@ ramips_setup_interfaces()
 	ubnt,unifi-nanohd)
 		ucidef_set_interface_lan "lan"
 		;;
+	ampedwireless,ally-r1900k|\
 	gehua,ghl-r-001|\
 	hiwifi,hc5962|\
 	xiaomi,mi-router-ac2100|\
@@ -75,6 +77,15 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
+	ampedwireless,ally-00x19k)
+		lan_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
+		label_mac=$lan_mac
+		;;
+	ampedwireless,ally-r1900k)
+		lan_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
+		wan_mac=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
+		label_mac=$lan_mac
+		;;
 	asus,rt-ac65p|\
 	asus,rt-ac85p)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env et1macaddr)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -27,6 +27,12 @@ platform_do_upgrade() {
 			fi
 		}
 		;;
+	ampedwireless,ally-00x19k|\
+	ampedwireless,ally-r1900k)
+		if [ "$(fw_printenv -n bootImage 2>/dev/null)" != "0" ]; then
+			fw_setenv bootImage 0 || exit 1
+		fi
+		;;
 	mikrotik,routerboard-750gr3|\
 	mikrotik,routerboard-760igs|\
 	mikrotik,routerboard-m11g|\
@@ -43,6 +49,8 @@ platform_do_upgrade() {
 	esac
 
 	case "$board" in
+	ampedwireless,ally-00x19k|\
+	ampedwireless,ally-r1900k|\
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
 	dlink,dir-1960-a1|\


### PR DESCRIPTION
Amped Wireless ALLY is a whole-home WiFi kit,
with a router (model ALLY-R1900K) and an
Extender (model ALLY-00X19K).
Both are devices are 11ac and based on
MediaTek MT7621AT and MT7615N chips.  The units
are nearly identical, except the Extender lacks
a USB port and has a single Ethernet port.

Specification:
- SoC: MediaTek MT7621AT (2C/4T) @ 880MHz
- RAM: 128MB DDR3 (Nanya NT5CC64M16GP-DI)
- FLASH: 128MB NAND (Winbond W29N01GVSIAA)
- WiFi: 2.4/5 GHz 4T4R
  - 2.4GHz MediaTek MT7615N bgn
  - 5GHz MediaTek MT7615N nac
- Switch: SoC integrated Gigabit Switch
- USB: 1x USB3 (Router only)
- BTN: Reset, WPS
- LED: single RGB
- UART:  through-hole on PCB.
   J1: pin1 (square pad, towards rear)=3.3V, pin2=RX,
   pin3=GND, pin4=TX.  Settings: 57600/8N1.

Note regarding dual system partitions
-------------------------------------

The vendor firmware and boot loader use a dual partition
scheme.  The boot partition is decided by the bootImage
U-boot environment variable: 0 for the 1st partition, 1
for the 2nd.

OpenWrt does not support this scheme and will always use the
first OS partition.  It will set bootImage to 0 during
installation, making sure the first partition is selected
by the boot loader.

Also, because we can't be sure which partition is active to
begin with, a 2-step flash process is used.  We first
flash an initramfs image, then follow with a
regular sysupgrade.

Installation:

Router (ALLY-R1900K)
1) Install the flashable initramfs image via the OEM web-interface.
  You can use WiFi or Ethernet.
  The direct URL is:  http://192.168.3.1/07_06_00_firmware.html
  a. No login is needed, and you'll be in their setup wizard.
  b. You might get a warning about not being connected to the Internet.
  c. Towards the bottom of the page will be a section entitled "Or
  Manually Upgrade Firmware from a File:"
  where you can manually choose and upload a firmware file.
  d: Click "Choose File", select the OpenWRT "initramfs" image
  and click "Upload."
2) The Router will flash the OpenWrt initramfs image and reboot.  After
  booting, LuCI will be available on 192.168.1.1.
3) Log into LuCI as root; there is no password.
4) Optional (but recommended) is to backup the OEM firmware before
  continuing; see process below.
5) Complete the Installation by flashing a full OpenWRT image.  Note:
  you may use the sysupgrade command line tool in lieu of the UI if
  you prefer.
  a.  Choose System -> Backup/Flash Firmware.
  b.  Click "Flash Image..." under "Flash new firmware image"
  c.  Click "Browse..." and then select the sysupgrade file.
  d.  Click Upload to upload the sysupgrade file.
  e.  Important:  uncheck "Keep settings and retain the current
      configuration" for this initial installation.
  f.  Click "Continue" to flash the firmware.
  g.  The device will reboot and OpenWRT is installed.

Extender (ALLY-00X19K)
1) This device requires a TFTP recovery procedure to do an initial load
  of OpenWRT.  Start by configuring a computer as a TFTP client:
  a. Install a TFTP client (server not necessary)
  b. Configure an Ethernet interface to 192.168.1.x/24; don't use .1 or .6
  c. Connect the Ethernet to the sole Ethernet port on the X19K.
2) Put the ALLY Extender in TFTP recovery mode.
  a. Do this by pressing and holding the reset button on the bottom
  while connecting the power.
  b. As soon as the LED lights up green (roughly 2-3 seconds), release
  the button.
3) Start the TFTP transfer of the Initramfs image from your setup machine.
For example, from Linux:
tftp -v -m binary 192.168.1.6 69 -c put initramfs.bin
4) The Extender will flash the OpenWrt initramfs image and reboot.  After
booting, LuCI will be available on 192.168.1.1.
5) Log into LuCI as root; there is no password.
6) Optional (but recommended) is to backup the OEM firmware before
  continuing; see process below.
7) Complete the Installation by flashing a full OpenWRT image.  Note:
  you may use the sysupgrade command line tool in lieu of the UI if
  you prefer.
  a.  Choose System -> Backup/Flash Firmware.
  b.  Click "Flash Image..." under "Flash new firmware image"
  c.  Click "Browse..." and then select the sysupgrade file.
  d.  Click Upload to upload the sysupgrade file.
  e.  Important:  uncheck "Keep settings and retain the current
      configuration" for this initial installation.
  f.  Click "Continue" to flash the firmware.
  g.  The device will reboot and OpenWRT is installed.

Backup the OEM Firmware:
-----------------------

There isn't any firmware released for the ALLY devices on
the Amped Wireless web site. Reverting back to the OEM firmware is
not possible unless we have a backup of the original OEM
firmware.

The OEM firmware may be stored on either /dev/mtd3 ("firmware")
or /dev/mtd6 ("oem").  We can't be sure which was overwritten
with the initramfs image, so backup both partitions to be safe.

  1) Once logged into LuCI, navigate to System -> Backup/Flash Firmware.
  2) Under "Save mtdblock contents," first select "firmware" and click
  "Save mtdblock" to download the image.
  3) Repeat the process, but select "oem" from the pull-down menu.

Revert to the OEM Firmware:
--------------------------
* U-boot TFTP:
  Follow the TFTP recovery steps for the Extender, and use the
  backup image.

* OpenWrt "Flash Firmware" interface:
  Upload the backup image and select "Force update"
  before continuing.

Signed-off-by: Jonathan Sturges <jsturges@redhat.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
